### PR TITLE
Implement initial socket room management

### DIFF
--- a/next/src/app/[roomId]/page.tsx
+++ b/next/src/app/[roomId]/page.tsx
@@ -4,6 +4,5 @@ import GameLobby from "@/components/GameLobby";
 import EnterName from "@/components/EnterName";
 
 export default function Page({ params }: { params: { roomId: string } }) {
-  // return <GameLobby roomId={params.roomId} />;
-  return <EnterName />;
+  return <EnterName roomId={params.roomId} />;
 }

--- a/next/src/components/Chat.tsx
+++ b/next/src/components/Chat.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import React, { useState } from "react";
+import { Socket } from "socket.io-client";
+import { Events } from "@/lib/events";
+import { ChatMessage } from "@/lib/types";
+
+interface ChatProps {
+  socket: Socket;
+  roomId: string;
+  playerName: string;
+  messages: ChatMessage[];
+}
+
+const Chat: React.FC<ChatProps> = ({ socket, roomId, playerName, messages }) => {
+  const [input, setInput] = useState("");
+
+  const sendMessage = () => {
+    if (!input.trim()) return;
+    socket.emit(Events.CHAT_MESSAGE, roomId, playerName, input);
+    setInput("");
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold">Chat</h2>
+      <div className="mb-2 h-40 overflow-y-auto border p-2">
+        {messages.map((m, idx) => (
+          <div key={idx}>
+            <strong>{m.name}: </strong>
+            <span>{m.message}</span>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          className="grow rounded border px-2"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") sendMessage();
+          }}
+        />
+        <button className="rounded bg-blue-500 px-4 py-1 text-white" onClick={sendMessage}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Chat;

--- a/next/src/components/EnterName.tsx
+++ b/next/src/components/EnterName.tsx
@@ -10,6 +10,9 @@ const onEvents: OnEvents = {
     console.log(`Room ${roomId} created`);
     navigate(roomId.slice(0, 4));
   },
+  [Events.ROOM_JOINED]: (roomId: string) => {
+    console.log(`Joined room ${roomId}`);
+  },
   [Events.DISCONNECT]: () => {
     console.log("User disconnected");
   },
@@ -28,7 +31,8 @@ export default function EnterName({ roomId }: Props): React.ReactNode {
   };
 
   const handleJoinRoom = () => {
-    socket.emit("join-room", name);
+    if (!roomId) return;
+    socket.emit(Events.JOIN_ROOM, roomId, name);
   };
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/next/src/components/EnterName.tsx
+++ b/next/src/components/EnterName.tsx
@@ -1,29 +1,36 @@
 "use client";
 
 import { navigate } from "@/actions";
-import useSocket, { OnEvents } from "@/hooks/useSocket";
+import useSocket from "@/hooks/useSocket";
 import { Events } from "@/lib/events";
+import GameLobby from "@/components/GameLobby";
 import React, { useState } from "react";
-
-const onEvents: OnEvents = {
-  [Events.ROOM_CREATED]: (roomId: string) => {
-    console.log(`Room ${roomId} created`);
-    navigate(roomId.slice(0, 4));
-  },
-  [Events.ROOM_JOINED]: (roomId: string) => {
-    console.log(`Joined room ${roomId}`);
-  },
-  [Events.DISCONNECT]: () => {
-    console.log("User disconnected");
-  },
-};
 
 type Props = { roomId?: string };
 export default function EnterName({ roomId }: Props): React.ReactNode {
-  const socket = useSocket(onEvents);
+  const [joined, setJoined] = useState(false);
   const [name, setName] = useState("");
   const [buttonDisabled, setButtonsDisabled] = useState(true);
   const [errorMessage, setErrorMessage] = useState("");
+
+  const socket = useSocket({
+    [Events.ROOM_CREATED]: (newRoomId: string) => {
+      console.log(`Room ${newRoomId} created`);
+      navigate(newRoomId.slice(0, 4));
+    },
+    [Events.ROOM_JOINED]: (joinedRoomId: string) => {
+      console.log(`Joined room ${joinedRoomId}`);
+      if (joinedRoomId) {
+        setJoined(true);
+      } else {
+        setErrorMessage("Room not found");
+        setButtonsDisabled(false);
+      }
+    },
+    [Events.DISCONNECT]: () => {
+      console.log("User disconnected");
+    },
+  });
 
   const handleCreateRoom = () => {
     setButtonsDisabled(true);
@@ -45,6 +52,10 @@ export default function EnterName({ roomId }: Props): React.ReactNode {
       setErrorMessage("Name must be at least 3 characters long");
     }
   };
+
+  if (joined && roomId) {
+    return <GameLobby socket={socket} roomId={roomId} playerName={name} />;
+  }
 
   return (
     <>

--- a/next/src/components/EnterName.tsx
+++ b/next/src/components/EnterName.tsx
@@ -13,24 +13,29 @@ export default function EnterName({ roomId }: Props): React.ReactNode {
   const [buttonDisabled, setButtonsDisabled] = useState(true);
   const [errorMessage, setErrorMessage] = useState("");
 
-  const socket = useSocket({
-    [Events.ROOM_CREATED]: (newRoomId: string) => {
-      console.log(`Room ${newRoomId} created`);
-      navigate(newRoomId.slice(0, 4));
-    },
-    [Events.ROOM_JOINED]: (joinedRoomId: string) => {
-      console.log(`Joined room ${joinedRoomId}`);
-      if (joinedRoomId) {
-        setJoined(true);
-      } else {
-        setErrorMessage("Room not found");
-        setButtonsDisabled(false);
-      }
-    },
-    [Events.DISCONNECT]: () => {
-      console.log("User disconnected");
-    },
-  });
+  const socket = useSocket(
+    React.useMemo(
+      () => ({
+        [Events.ROOM_CREATED]: (newRoomId: string) => {
+          console.log(`Room ${newRoomId} created`);
+          navigate(newRoomId.slice(0, 4));
+        },
+        [Events.ROOM_JOINED]: (joinedRoomId: string) => {
+          console.log(`Joined room ${joinedRoomId}`);
+          if (joinedRoomId) {
+            setJoined(true);
+          } else {
+            setErrorMessage("Room not found");
+            setButtonsDisabled(false);
+          }
+        },
+        [Events.DISCONNECT]: () => {
+          console.log("User disconnected");
+        },
+      }),
+      [],
+    ),
+  );
 
   const handleCreateRoom = () => {
     setButtonsDisabled(true);

--- a/next/src/components/GameLobby.tsx
+++ b/next/src/components/GameLobby.tsx
@@ -1,15 +1,38 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import copy from "copy-to-clipboard";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import { Socket } from "socket.io-client";
+import { Events } from "@/lib/events";
+import { ChatMessage, Player } from "@/lib/types";
+import PlayerList from "./PlayerList";
+import Chat from "./Chat";
 
 interface LobbyProps {
   roomId: string;
+  socket: Socket;
+  playerName: string;
 }
 
-const Lobby: React.FC<LobbyProps> = ({ roomId }) => {
+const Lobby: React.FC<LobbyProps> = ({ roomId, socket, playerName }) => {
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+
+  useEffect(() => {
+    const handlePlayers = (pls: Player[]) => setPlayers(pls);
+    const handleMessage = (msg: ChatMessage) =>
+      setMessages((m) => [...m, msg]);
+
+    socket.on(Events.PLAYERS_UPDATE, handlePlayers);
+    socket.on(Events.CHAT_MESSAGE, handleMessage);
+
+    return () => {
+      socket.off(Events.PLAYERS_UPDATE, handlePlayers);
+      socket.off(Events.CHAT_MESSAGE, handleMessage);
+    };
+  }, [socket]);
   const handleCopy = () => {
     copy("localhost:3000/" + roomId.slice(0, 4));
     toast("Copied to clipboard!");
@@ -27,6 +50,8 @@ const Lobby: React.FC<LobbyProps> = ({ roomId }) => {
             Copy Invite Link
           </button>
         </div>
+        <PlayerList players={players} />
+        <Chat socket={socket} roomId={roomId} playerName={playerName} messages={messages} />
       </div>
       <ToastContainer />
     </>

--- a/next/src/components/MainMenu.tsx
+++ b/next/src/components/MainMenu.tsx
@@ -27,7 +27,7 @@ const MainMenu: React.FC = () => {
   };
 
   const handleJoinRoom = () => {
-    socket.emit(Events.JOIN_ROOM, roomName);
+    navigate(roomName);
   };
 
   return (

--- a/next/src/components/PlayerList.tsx
+++ b/next/src/components/PlayerList.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import React from "react";
+import { Player } from "@/lib/types";
+
+interface PlayerListProps {
+  players: Player[];
+}
+
+const PlayerList: React.FC<PlayerListProps> = ({ players }) => {
+  return (
+    <div className="mb-4">
+      <h2 className="text-xl font-bold">Players</h2>
+      <ul>
+        {players.map((p) => (
+          <li key={p.name}>{p.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default PlayerList;

--- a/next/src/hooks/useSocket.ts
+++ b/next/src/hooks/useSocket.ts
@@ -7,28 +7,30 @@ export type OnEvents = {
 
 // takes a map of onEvents that map strings to functions
 const useSocket = (onEvents?: OnEvents) => {
-  const [socket, setSocket] = useState<Socket | null>(null);
+  const [socket] = useState<Socket>(() => io());
 
   useEffect(() => {
-    const newSocket = io();
-    setSocket(newSocket);
-
-    if (onEvents) {
-      for (const [event, handler] of Object.entries(onEvents)) {
-        // check type of event and handler
-        if (typeof event !== "string" || typeof handler !== "function") {
-          throw new Error("Invalid event or handler");
-        }
-        newSocket.on(event, handler);
+    if (!onEvents) return;
+    for (const [event, handler] of Object.entries(onEvents)) {
+      if (typeof event !== "string" || typeof handler !== "function") {
+        throw new Error("Invalid event or handler");
       }
+      socket.on(event, handler);
     }
-
     return () => {
-      newSocket.disconnect();
+      for (const [event, handler] of Object.entries(onEvents)) {
+        socket.off(event, handler);
+      }
     };
-  }, [onEvents]);
+  }, [socket, onEvents]);
 
-  return socket as Socket;
+  useEffect(() => {
+    return () => {
+      socket.disconnect();
+    };
+  }, [socket]);
+
+  return socket;
 };
 
 export default useSocket;

--- a/next/src/lib/events.ts
+++ b/next/src/lib/events.ts
@@ -20,4 +20,10 @@ export enum Events {
 
   /** Event fired when the server confirms a user joined a room. */
   ROOM_JOINED = "room-joined",
+
+  /** Event fired when the list of players in a room changes. */
+  PLAYERS_UPDATE = "players-update",
+
+  /** Event fired to transmit chat messages. */
+  CHAT_MESSAGE = "chat-message",
 }

--- a/next/src/lib/events.ts
+++ b/next/src/lib/events.ts
@@ -17,4 +17,7 @@ export enum Events {
 
   /** Event fired when a user joins a room. */
   JOIN_ROOM = "join-room",
+
+  /** Event fired when the server confirms a user joined a room. */
+  ROOM_JOINED = "room-joined",
 }

--- a/next/src/lib/managers/RoomManager.ts
+++ b/next/src/lib/managers/RoomManager.ts
@@ -12,8 +12,12 @@ export default class RoomManager {
 
   constructor(private io: Server) {
     io.on(Events.CONNECTION, (socket) => {
-      socket.on(Events.CREATE_ROOM, this.handleCreateRoom);
-      socket.on(Events.JOIN_ROOM, this.handleJoinRoom);
+      socket.on(Events.CREATE_ROOM, (name?: string) =>
+        this.handleCreateRoom(socket, name),
+      );
+      socket.on(Events.JOIN_ROOM, (roomId: string, name: string) =>
+        this.handleJoinRoom(socket, roomId, name),
+      );
     });
   }
 
@@ -23,10 +27,7 @@ export default class RoomManager {
    * @param ownerName - The name of the room owner.
    * @param callback - A callback function that will be called with the generated roomId.
    */
-  private handleCreateRoom = (
-    ownerName: string,
-    callback: (roomId: string) => void,
-  ) => {
+  private handleCreateRoom = (socket: Socket, ownerName = "") => {
     const roomId = generateRoomId();
     const owner: Player = {
       name: ownerName,
@@ -36,10 +37,11 @@ export default class RoomManager {
     this.rooms.set(roomId, {
       roomId,
       owner,
-      players: [owner],
+      players: ownerName ? [owner] : [],
       gameState: getInitialGameState(),
     });
-    callback(roomId);
+    socket.join(roomId);
+    socket.emit(Events.ROOM_CREATED, roomId);
   };
 
   /**
@@ -50,21 +52,23 @@ export default class RoomManager {
    * @param callback - A callback function that will be called with a boolean indicating the success of the operation.
    */
   private handleJoinRoom = (
+    socket: Socket,
     roomId: string,
     playerName: string,
-    callback: (success: boolean) => void,
   ) => {
     const room = this.rooms.get(roomId);
-    if (room) {
-      const player: Player = {
-        name: playerName,
-        team: TeamStatus.None,
-        role: Role.None,
-      };
-      room.players.push(player);
-      callback(true);
-    } else {
-      callback(false);
+    if (!room) {
+      socket.emit(Events.ROOM_JOINED, "");
+      return;
     }
+
+    const player: Player = {
+      name: playerName,
+      team: TeamStatus.None,
+      role: Role.None,
+    };
+    room.players.push(player);
+    socket.join(roomId);
+    socket.emit(Events.ROOM_JOINED, roomId);
   };
 }

--- a/next/src/lib/managers/RoomManager.ts
+++ b/next/src/lib/managers/RoomManager.ts
@@ -18,6 +18,10 @@ export default class RoomManager {
       socket.on(Events.JOIN_ROOM, (roomId: string, name: string) =>
         this.handleJoinRoom(socket, roomId, name),
       );
+      socket.on(Events.CHAT_MESSAGE, (roomId: string, name: string, msg: string) =>
+        this.handleChatMessage(roomId, name, msg),
+      );
+      socket.on(Events.DISCONNECT, () => this.handleDisconnect(socket));
     });
   }
 
@@ -40,7 +44,12 @@ export default class RoomManager {
       players: ownerName ? [owner] : [],
       gameState: getInitialGameState(),
     });
-    socket.join(roomId);
+    if (ownerName) {
+      socket.data.roomId = roomId;
+      socket.data.name = ownerName;
+      socket.join(roomId);
+      this.broadcastPlayers(roomId);
+    }
     socket.emit(Events.ROOM_CREATED, roomId);
   };
 
@@ -69,6 +78,33 @@ export default class RoomManager {
     };
     room.players.push(player);
     socket.join(roomId);
+    socket.data.roomId = roomId;
+    socket.data.name = playerName;
     socket.emit(Events.ROOM_JOINED, roomId);
+    this.broadcastPlayers(roomId);
+  };
+
+  private handleChatMessage = (
+    roomId: string,
+    name: string,
+    message: string,
+  ) => {
+    this.io.to(roomId).emit(Events.CHAT_MESSAGE, { name, message });
+  };
+
+  private handleDisconnect = (socket: Socket) => {
+    const { roomId, name } = socket.data as { roomId?: string; name?: string };
+    if (!roomId || !name) return;
+    const room = this.rooms.get(roomId);
+    if (!room) return;
+    room.players = room.players.filter((p) => p.name !== name);
+    this.broadcastPlayers(roomId);
+  };
+
+  private broadcastPlayers = (roomId: string) => {
+    const room = this.rooms.get(roomId);
+    if (!room) return;
+    this.io.to(roomId).emit(Events.PLAYERS_UPDATE, room.players);
   };
 }
+

--- a/next/src/lib/types.ts
+++ b/next/src/lib/types.ts
@@ -85,3 +85,11 @@ export enum Role {
   Guesser,
   None,
 }
+
+/** Represents a chat message. */
+export interface ChatMessage {
+  /** Name of the player sending the message. */
+  name: string;
+  /** The message text. */
+  message: string;
+}


### PR DESCRIPTION
## Summary
- create new ROOM_JOINED event
- support room join logic and emit updated events
- hook up EnterName component with join events and roomId prop
- navigate to room directly from main menu

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68425cf92508832a9426db15e42840b7